### PR TITLE
Rotate partner cards automatically

### DIFF
--- a/src/containers/withPartnersShowcaser.js
+++ b/src/containers/withPartnersShowcaser.js
@@ -5,10 +5,38 @@ import PartnerCardMobile from "../components/PartnerCardMobile";
 export default showcasePartnersData => WrappedComponent => {
   class withPartnersShowcaser extends Component {
     state = {
+      currentIndex: 0,
       selectedPartner: showcasePartnersData[0],
     };
 
+    componentDidMount() {
+      this.interval = setInterval(() => {
+        const newCurrentIndex =
+          this.state.currentIndex === showcasePartnersData.length - 1
+            ? 0
+            : this.state.currentIndex + 1;
+        const newSelectedPartner = showcasePartnersData[newCurrentIndex];
+
+        this.setState({
+          currentIndex: newCurrentIndex,
+          selectedPartner: newSelectedPartner,
+        });
+      }, 7000);
+    }
+
+    componentWillUnmount() {
+      this.clearComponentInterval();
+    }
+
+    clearComponentInterval = () => {
+      clearInterval(this.interval);
+
+      this.interval = null;
+    };
+
     handleSelect = event => {
+      this.clearComponentInterval();
+
       const partnerName = event.currentTarget.name;
 
       if (!partnerName) return;


### PR DESCRIPTION
As suggested by Francisco Baila. Partner cards change every 7 seconds. When a partner card is selected automatically, this behaviour is disabled.