### PR TITLE
Add new responsive renderer component

### DIFF
--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -2,13 +2,16 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import Img from "gatsby-image";
 import classNames from "classnames/bind";
+import withWindowDimensions from "root/containers/withWindowDimensions";
 
 import "./index.css";
 
 const breakpointMobile = 768;
 
+@withWindowDimensions
 export default class Background extends Component {
   static propTypes = {
+    width: PropTypes.number.isRequired,
     image: PropTypes.shape({}).isRequired,
     children: PropTypes.node.isRequired,
     blendMode: PropTypes.oneOf(["normal", "difference"]),
@@ -26,26 +29,8 @@ export default class Background extends Component {
     poster: "",
   };
 
-  state = {
-    width: undefined,
-  };
-
-  componentDidMount = () => {
-    window.addEventListener("resize", this.updateDimensions);
-    this.updateDimensions();
-  };
-
-  componentWillUnmount = () => {
-    window.removeEventListener("resize", this.updateDimensions);
-  };
-
-  updateDimensions = () => {
-    this.setState({ width: document.documentElement.clientWidth });
-  };
-
   renderBackground = () => {
-    const { width } = this.state;
-    const { video, image, poster } = this.props;
+    const { width, video, image, poster } = this.props;
 
     if (video && width > breakpointMobile) {
       return (
@@ -57,7 +42,7 @@ export default class Background extends Component {
           autoPlay
           loop
           playsInline
-          preload
+          preload="true"
         />
       );
     }

--- a/src/components/BackgroundVideoText/index.js
+++ b/src/components/BackgroundVideoText/index.js
@@ -41,7 +41,6 @@ export default class BackgroundVideoText extends Component {
             </defs>
             <rect width="100%" height="100%" />
           </svg>
-          <rect width="100%" height="100%" />
           <video
             src={video}
             poster={poster}
@@ -49,7 +48,7 @@ export default class BackgroundVideoText extends Component {
             autoPlay
             loop
             playsInline
-            preload
+            preload="true"
           />
         </Typography>
       </div>

--- a/src/components/ResponsiveRenderer/index.js
+++ b/src/components/ResponsiveRenderer/index.js
@@ -1,0 +1,43 @@
+import { Component } from "react";
+import PropTypes from "prop-types";
+import withWindowDimensions from "root/containers/withWindowDimensions";
+
+const breakpointMobile = 768;
+const breakpointDesktop = 1268;
+
+@withWindowDimensions
+export default class ResponsiveRenderer extends Component {
+  static propTypes = {
+    width: PropTypes.number,
+    renderDefault: PropTypes.func.isRequired,
+    renderDesktop: PropTypes.func.isRequired,
+    renderTablet: PropTypes.func.isRequired,
+    renderMobile: PropTypes.func.isRequired,
+  };
+
+  static defaultProps = {
+    width: null,
+  };
+
+  render() {
+    const {
+      width,
+      renderDefault,
+      renderDesktop,
+      renderTablet,
+      renderMobile,
+    } = this.props;
+
+    if (!width) return renderDefault();
+
+    if (width >= breakpointDesktop) {
+      return renderDesktop();
+    }
+
+    if (width < breakpointMobile) {
+      return renderMobile();
+    }
+
+    return renderTablet();
+  }
+}

--- a/src/containers/withWindowDimensions.js
+++ b/src/containers/withWindowDimensions.js
@@ -1,0 +1,35 @@
+import React, { Component } from "react";
+
+export default WrappedComponent => {
+  class withWindowDimensions extends Component {
+    state = {
+      width: null,
+      height: null,
+    };
+
+    componentDidMount = () => {
+      this.updateDimensions();
+
+      window.addEventListener("resize", this.updateDimensions);
+    };
+
+    componentWillUnmount = () => {
+      window.removeEventListener("resize", this.updateDimensions);
+    };
+
+    updateDimensions = () => {
+      this.setState({
+        width: document.documentElement.clientWidth,
+        height: document.documentElement.clientHeight,
+      });
+    };
+
+    render() {
+      const { width, height } = this.state;
+
+      return <WrappedComponent {...this.props} width={width} height={height} />;
+    }
+  }
+
+  return withWindowDimensions;
+};

--- a/src/sections/CompanyHero/index.js
+++ b/src/sections/CompanyHero/index.js
@@ -6,6 +6,7 @@ import Typography from "root/components/Typography";
 
 import video from "root/assets/videos/text-video.mp4";
 import textBackground from "root/assets/images/text-img.jpg";
+import ResponsiveRenderer from "../../components/ResponsiveRenderer";
 
 const column = 114;
 const gutter = 28;
@@ -16,27 +17,6 @@ const breakpointMobile = 768;
 const breakpointDesktop = 1268;
 
 export default class CompanyHero extends Component {
-  state = {
-    isJsReady: false,
-  };
-
-  componentDidMount = () => {
-    this.updateDimensions();
-
-    window.addEventListener("resize", this.updateDimensions);
-  };
-
-  componentWillUnmount = () => {
-    window.removeEventListener("resize", this.updateDimensions);
-  };
-
-  updateDimensions = () => {
-    this.setState({
-      width: document.documentElement.clientWidth,
-      isJsReady: true,
-    });
-  };
-
   renderDesktop = () => (
     <Section>
       <BackgroundVideoText
@@ -86,18 +66,13 @@ export default class CompanyHero extends Component {
   );
 
   render() {
-    if (!this.state.isJsReady) return this.renderNoScript();
-
-    const { width } = this.state;
-
-    if (width >= breakpointDesktop) {
-      return this.renderDesktop();
-    }
-
-    if (width < breakpointMobile) {
-      return this.renderMobile();
-    }
-
-    return this.renderTablet();
+    return (
+      <ResponsiveRenderer
+        renderDefault={this.renderNoScript}
+        renderDesktop={this.renderDesktop}
+        renderTablet={this.renderTablet}
+        renderMobile={this.renderMobile}
+      />
+    );
   }
 }

--- a/src/sections/CompanyMagical/index.js
+++ b/src/sections/CompanyMagical/index.js
@@ -14,7 +14,7 @@ const CompanyMagical = ({ data }) => (
     image={data.magicalPower.image.fluid}
     maxWidth
   >
-    <Section separator verticalSpacing="false">
+    <Section separator verticalSpacing={false}>
       <div styleName="title">
         <Typography variant="h2" fontFamily="meta-serif">
           The magical power happens when honesty, transparency and commitment

--- a/src/sections/ServicesHero/index.js
+++ b/src/sections/ServicesHero/index.js
@@ -3,6 +3,7 @@ import Section from "root/components/Section";
 import Typography from "root/components/Typography";
 import BackgroundVideoText from "root/components/BackgroundVideoText";
 import BackgroundImageText from "root/components/BackgroundImageText";
+import ResponsiveRenderer from "root/components/ResponsiveRenderer";
 
 import video from "root/assets/videos/text-video.mp4";
 import textBackground from "root/assets/images/text-img.jpg";
@@ -14,32 +15,7 @@ const gutter = 28;
 const eightColumns = 8 * column + 7 * gutter;
 const fiveColumns = 5 * column + 4 * gutter;
 
-const breakpointMobile = 768;
-const breakpointDesktop = 1268;
-
 export default class ServicesHero extends Component {
-  state = {
-    isJsReady: false,
-    width: undefined,
-  };
-
-  componentDidMount() {
-    this.updateDimensions();
-
-    window.addEventListener("resize", this.updateDimensions);
-  }
-
-  componentWillUnmount = () => {
-    window.removeEventListener("resize", this.updateDimensions);
-  };
-
-  updateDimensions = () => {
-    this.setState({
-      width: document.documentElement.clientWidth,
-      isJsReady: true,
-    });
-  };
-
   renderCopy = () => (
     <div>
       <div styleName="left">
@@ -75,7 +51,7 @@ export default class ServicesHero extends Component {
     <Section>
       <BackgroundImageText image={textBackground}>
         <Typography weight="bold" variant="h1" fontFamily="meta-serif">
-          &#8203; A dynamic team to design and develop your product
+          &#8203;A dynamic team to design and develop your product
         </Typography>
       </BackgroundImageText>
       {this.renderCopy()}
@@ -104,18 +80,13 @@ export default class ServicesHero extends Component {
   );
 
   render() {
-    if (!this.state.isJsReady) return this.renderNoScript();
-
-    const { width } = this.state;
-
-    if (width >= breakpointDesktop) {
-      return this.renderDesktop();
-    }
-
-    if (width < breakpointMobile) {
-      return this.renderMobile();
-    }
-
-    return this.renderTablet();
+    return (
+      <ResponsiveRenderer
+        renderDefault={this.renderNoScript}
+        renderDesktop={this.renderDesktop}
+        renderTablet={this.renderTablet}
+        renderMobile={this.renderMobile}
+      />
+    );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1065,6 +1065,7 @@ ansi-styles@^2.2.1:
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
+  integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
   dependencies:
     color-convert "^1.9.0"
 
@@ -1317,6 +1318,7 @@ autoprefixer@^9.0.0:
 autoprefixer@^9.4.2:
   version "9.4.2"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-9.4.2.tgz#0234d20900684fc4bfb67926493deb68384067f5"
+  integrity sha512-tYQYJvZvqlJCzF+BLC//uAcdT/Yy4ik9bwZRXr/EehUJ/bjjpTthsWTy8dpowdoIE1sLCDf1ch4Eb2cOSzZC9w==
   dependencies:
     browserslist "^4.3.5"
     caniuse-lite "^1.0.30000914"
@@ -2156,6 +2158,7 @@ browserslist@^4.0.0, browserslist@^4.1.0, browserslist@^4.3.3:
 browserslist@^4.3.5:
   version "4.3.5"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.3.5.tgz#1a917678acc07b55606748ea1adf9846ea8920f7"
+  integrity sha512-z9ZhGc3d9e/sJ9dIx5NFXkKoaiQTnrvrMsN3R1fGb1tkWWNSz12UewJn9TNxGo1l7J23h0MRaPmk7jfeTZYs1w==
   dependencies:
     caniuse-lite "^1.0.30000912"
     electron-to-chromium "^1.3.86"
@@ -2375,6 +2378,7 @@ caniuse-lite@^1.0.30000823:
 caniuse-lite@^1.0.30000912, caniuse-lite@^1.0.30000914:
   version "1.0.30000918"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000918.tgz#6288f79da3c5c8b45e502f47ad8f3eb91f1379a9"
+  integrity sha512-CAZ9QXGViBvhHnmIHhsTPSWFBujDaelKnUj7wwImbyQRxmXynYqKGi3UaZTSz9MoVh+1EVxOS/DFIkrJYgR3aw==
 
 capture-stack-trace@^1.0.0:
   version "1.0.1"
@@ -2630,12 +2634,14 @@ collection-visit@^1.0.0:
 color-convert@^1.3.0, color-convert@^1.8.2, color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
   dependencies:
     color-name "1.1.3"
 
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
 color-name@^1.0.0:
   version "1.1.4"
@@ -3749,6 +3755,7 @@ electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.82:
 electron-to-chromium@^1.3.86:
   version "1.3.90"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.90.tgz#b4c51b8303beff18f2b74817402bf4898e09558a"
+  integrity sha512-IjJZKRhFbWSOX1w0sdIXgp4CMRguu6UYcTckyFF/Gjtemsu/25eZ+RXwFlV+UWcIueHyQA1UnRJxocTpH5NdGA==
 
 elliptic@^6.0.0:
   version "6.4.1"
@@ -3894,6 +3901,7 @@ escape-html@~1.0.3:
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
+  integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
 eslint-config-airbnb-base@^12.1.0:
   version "12.1.0"
@@ -5530,6 +5538,7 @@ has-flag@^1.0.0:
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+  integrity sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
 
 has-gulplog@^0.1.0:
   version "0.1.0"
@@ -7556,6 +7565,7 @@ node-releases@^1.0.1:
 node-releases@^1.0.5:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.1.tgz#8fff8aea1cfcad1fb4205f805149054fbf73cafd"
+  integrity sha512-2UXrBr6gvaebo5TNF84C66qyJJ6r0kxBObgZIDX3D3/mt1ADKiHux3NJPWisq0wxvJJdkjECH+9IIKYViKj71Q==
   dependencies:
     semver "^5.3.0"
 
@@ -7599,6 +7609,7 @@ normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
 normalize-range@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/normalize-range/-/normalize-range-0.1.2.tgz#2d10c06bdfd312ea9777695a4d28439456b75942"
+  integrity sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=
 
 normalize-selector@^0.2.0:
   version "0.2.0"
@@ -7662,6 +7673,7 @@ null-loader@^0.1.1:
 num2fraction@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/num2fraction/-/num2fraction-1.2.2.tgz#6f682b6a027a4e9ddfa4564cd2589d1d4e669ede"
+  integrity sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=
 
 number-is-nan@^1.0.0:
   version "1.0.1"
@@ -10226,6 +10238,7 @@ source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@^0.5.7:
 source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 sparkles@^1.0.0:
   version "1.0.1"
@@ -10656,6 +10669,7 @@ supports-color@^3.2.3:
 supports-color@^5.1.0, supports-color@^5.3.0, supports-color@^5.4.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
+  integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
 


### PR DESCRIPTION
The responsive renderer component takes 4 props, renderDefault, renderDesktop, renderTablet, renderMobile, and renders based on the width of the client window. While JS is loading the component will render whats inside `renderDefault`, and this prop is optional if you don't want to render nothing until you have the size of the window. Noscript should be added on the `renderDefault` function if needed.

Also adds high order component to listen for resize events.