### PR TITLE
Fix Safari background overlay bug

### DIFF
--- a/src/components/Background/index.css
+++ b/src/components/Background/index.css
@@ -6,6 +6,12 @@
   overflow: hidden;
 }
 
+.children {
+  position: relative;
+
+  z-index: 2;
+}
+
 .max-width {
   max-width: $ten-columns;
   margin: 0 auto;
@@ -26,8 +32,6 @@
   bottom: 0;
   left: 0;
 
-  z-index: -2;
-
   width: 100%;
   height: 100%;
 
@@ -46,7 +50,6 @@
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: -2;
 
   width: 100%;
   height: 100%;
@@ -71,7 +74,7 @@
   bottom: 0;
   left: 0;
 
-  z-index: -1;
+  z-index: 1;
 
   width: 100%;
   height: 100%;

--- a/src/components/Background/index.css
+++ b/src/components/Background/index.css
@@ -6,14 +6,6 @@
   overflow: hidden;
 }
 
-.visually-hidden { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
-  position: absolute !important;
-  height: 1px; width: 1px;
-  overflow: hidden;
-  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
-  clip: rect(1px, 1px, 1px, 1px);
-}
-
 .max-width {
   max-width: $ten-columns;
   margin: 0 auto;
@@ -42,6 +34,12 @@
   opacity: 0.9;
 }
 
+.image.hidden {
+  @include Breakpoint-tabletAndAbove {
+    display: none;
+  }
+}
+
 .video {
   position: absolute;
   top: 0;
@@ -59,6 +57,10 @@
   background-size: cover;
   opacity: 0.9;
   object-fit: cover;
+
+  @include Breakpoint-mobileOnly {
+    display: none;
+  }
 }
 
 .rect {

--- a/src/components/Background/index.css
+++ b/src/components/Background/index.css
@@ -6,6 +6,14 @@
   overflow: hidden;
 }
 
+.visually-hidden { /* https://snook.ca/archives/html_and_css/hiding-content-for-accessibility */
+  position: absolute !important;
+  height: 1px; width: 1px;
+  overflow: hidden;
+  clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+  clip: rect(1px, 1px, 1px, 1px);
+}
+
 .max-width {
   max-width: $ten-columns;
   margin: 0 auto;

--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -3,16 +3,11 @@ import PropTypes from "prop-types";
 import Img from "gatsby-image";
 import classNames from "classnames/bind";
 import VisibilitySensor from "react-visibility-sensor";
-import withWindowDimensions from "root/containers/withWindowDimensions";
 
 import "./index.css";
 
-const breakpointMobile = 768;
-
-@withWindowDimensions
 export default class Background extends Component {
   static propTypes = {
-    width: PropTypes.number,
     image: PropTypes.shape({
       base64: PropTypes.string.isRequired,
       src: PropTypes.string.isRequired,
@@ -27,8 +22,7 @@ export default class Background extends Component {
   };
 
   static defaultProps = {
-    width: null,
-    blendMode: "difference",
+    blendMode: "normal",
     color: "light-blue",
     maxWidth: false,
     video: "",
@@ -53,19 +47,12 @@ export default class Background extends Component {
   };
 
   renderBackground = () => {
-    const { video, image, autoPlay, width } = this.props;
+    const { video, image, autoPlay } = this.props;
 
-    if (video && width > breakpointMobile) {
+    if (video) {
       return (
         <>
-          <video
-            styleName="visually-hidden"
-            src={video}
-            poster={this.props.image.src}
-            muted
-            loop
-            type="video/mp4"
-          />
+          <Img styleName="image hidden" fluid={image} critical />
           <video
             style={{
               backgroundImage: `url(${this.props.image.base64})`,

--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -22,7 +22,7 @@ export default class Background extends Component {
   };
 
   static defaultProps = {
-    blendMode: "normal",
+    blendMode: "difference",
     color: "light-blue",
     maxWidth: false,
     video: "",

--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -59,18 +59,12 @@ export default class Background extends Component {
       return (
         <>
           <video
-            style={{
-              display: "none",
-            }}
+            styleName="visually-hidden"
             src={video}
             poster={this.props.image.src}
             muted
-            playsInline
-            preload="auto"
             loop
-            autoPlay={autoPlay}
             type="video/mp4"
-            ref={this.handleRef("video")}
           />
           <video
             style={{

--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -94,7 +94,7 @@ export default class Background extends Component {
           <div styleName={classnames} />
           {this.renderBackground()}
 
-          {children}
+          <div styleName="children">{children}</div>
         </div>
       </VisibilitySensor>
     );

--- a/src/components/Background/index.js
+++ b/src/components/Background/index.js
@@ -57,21 +57,37 @@ export default class Background extends Component {
 
     if (video && width > breakpointMobile) {
       return (
-        <video
-          style={{
-            backgroundImage: `url(${this.props.image.base64})`,
-          }}
-          styleName="video"
-          src={video}
-          poster={this.props.image.src}
-          muted
-          playsInline
-          preload="auto"
-          loop
-          autoPlay={autoPlay}
-          type="video/mp4"
-          ref={this.handleRef("video")}
-        />
+        <>
+          <video
+            style={{
+              display: "none",
+            }}
+            src={video}
+            poster={this.props.image.src}
+            muted
+            playsInline
+            preload="auto"
+            loop
+            autoPlay={autoPlay}
+            type="video/mp4"
+            ref={this.handleRef("video")}
+          />
+          <video
+            style={{
+              backgroundImage: `url(${this.props.image.base64})`,
+            }}
+            styleName="video"
+            src={video}
+            poster={this.props.image.src}
+            muted
+            playsInline
+            preload="auto"
+            loop
+            autoPlay={autoPlay}
+            type="video/mp4"
+            ref={this.handleRef("video")}
+          />
+        </>
       );
     }
 


### PR DESCRIPTION
Habemus fix, the problem was due to z-index shenaningans. Basically video tags were ignoring the negative z-index, so basically the background are at z-index 0 and the background children are at z-index 2. Problem solved.

Also removes Javascript based width detector from the background and use pure css to do it. About video tags being present in mobile, browsers do not download video tags with `display: none`, so we can save client's bandwith.