### PR TITLE
Fix videos not stretching on Edge and IE

### DIFF
--- a/src/components/Background/index.css
+++ b/src/components/Background/index.css
@@ -52,14 +52,13 @@
   left: 0;
 
   width: 100%;
-  height: 100%;
+  height: auto;
 
   background-attachment: fixed;
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
   opacity: 0.9;
-  object-fit: cover;
 
   @include Breakpoint-mobileOnly {
     display: none;


### PR DESCRIPTION
Solution? Remove object-fit and use `height: auto`