### PR TITLE
Add polyfill.io for Internet Explorer

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,6 +35,7 @@ module.exports = {
         root: path.join(__dirname, "src"),
       },
     },
+    "gatsby-plugin-polyfill-io",
     "gatsby-plugin-sitemap",
   ],
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gatsby-link": "^2.0.1",
     "gatsby-plugin-google-analytics": "^2.0.6",
     "gatsby-plugin-offline": "^2.0.9",
+    "gatsby-plugin-polyfill-io": "^1.0.5",
     "gatsby-plugin-postcss": "^2.0.0",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-plugin-root-import": "^2.0.4",

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -45,7 +45,6 @@ class Layout extends Component {
       <div>
         <Helmet>
           <title>{siteTitle}</title>
-          <script src="https://cdn.polyfill.io/v2/polyfill.min.js" />
           <meta name="description" content={siteDescription} />
           <meta name="keywords" content={siteKeywords} />
           <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/components/Layout/index.js
+++ b/src/components/Layout/index.js
@@ -45,6 +45,7 @@ class Layout extends Component {
       <div>
         <Helmet>
           <title>{siteTitle}</title>
+          <script src="https://cdn.polyfill.io/v2/polyfill.min.js" />
           <meta name="description" content={siteDescription} />
           <meta name="keywords" content={siteKeywords} />
           <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/yarn.lock
+++ b/yarn.lock
@@ -5627,6 +5627,13 @@ gatsby-plugin-page-creator@^2.0.4:
     parse-filepath "^1.0.1"
     slash "^1.0.0"
 
+gatsby-plugin-polyfill-io@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-polyfill-io/-/gatsby-plugin-polyfill-io-1.0.5.tgz#8cab3ee8668845c8785e8d759bbe23ba1582145b"
+  integrity sha512-xkjde+FkWfWpYj7cisGXePVXt1Gb84LgWlaT5OuSFs6wcnebhAAr8GNJctIzJFmlKOTdbTYQnwYuDl3i/w7nyw==
+  dependencies:
+    babel-runtime "^6.26.0"
+
 gatsby-plugin-postcss@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/gatsby-plugin-postcss/-/gatsby-plugin-postcss-2.0.1.tgz#598d5096cd2e2bc5a94aa0434ea4c8f771f4d1fc"


### PR DESCRIPTION
JS is not working on IE, this external library automatically injects needed polyfills based on the browser of the client.