### PR TITLE
Fix navbar zindex again

### DIFF
--- a/src/components/Navbar/index.css
+++ b/src/components/Navbar/index.css
@@ -173,4 +173,8 @@ $menu-icon-size: 30px;
   .ReactModal__Overlay--before-close {
     opacity: 0;
   }
+
+  .FixedNavbarModal__Overlay {
+    z-index: 3;
+  }
 }

--- a/src/components/Navbar/index.css
+++ b/src/components/Navbar/index.css
@@ -140,7 +140,14 @@ $menu-icon-size: 30px;
   }
 }
 
-.modal {
+.modal-fixed {
+  display: block;
+
+
+  background-color: $navbar-background;
+}
+
+.modal-menu {
   display: block;
 
   width: 100vw;

--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -38,7 +38,10 @@ export default class Navbar extends Component {
   };
 
   componentDidMount() {
-    window.addEventListener("scroll", this.handleScroll, { passive: true });
+    window.addEventListener("scroll", this.handleScroll, {
+      capture: true,
+      passive: true,
+    });
   }
 
   componentDidUpdate() {
@@ -71,10 +74,8 @@ export default class Navbar extends Component {
     if (newScroll < 200) {
       this.setState({ showFixedNavbar: false });
     } else {
-      this.setState({ showFixedNavbar: newScroll < this.oldScroll });
+      this.setState({ showFixedNavbar: true });
     }
-
-    this.oldScroll = window.pageYOffset || document.documentElement.scrollTop;
   };
 
   handleMenuToggle = () => {
@@ -189,16 +190,17 @@ export default class Navbar extends Component {
 
     return (
       <>
-        {menuOpen ? <div style={{ height: "44px" }} /> : null}
-        <Modal styleName="modal" isOpen={menuOpen}>
+        <Modal styleName="modal-fixed" isOpen={!menuOpen}>
+          {this.renderFixedNavbar()}
+        </Modal>
+        <Modal styleName="modal-menu" isOpen={menuOpen}>
           {this.renderInner()}
         </Modal>
-        {!menuOpen ? (
-          <>
-            {this.renderFixedNavbar()}
-            <Section verticalSpacing={false}>{this.renderInner()}</Section>
-          </>
-        ) : null}
+        {menuOpen ? (
+          <div style={{ height: "44px" }} />
+        ) : (
+          <Section verticalSpacing={false}>{this.renderInner()}</Section>
+        )}
       </>
     );
   }

--- a/src/components/Navbar/index.js
+++ b/src/components/Navbar/index.js
@@ -190,7 +190,7 @@ export default class Navbar extends Component {
 
     return (
       <>
-        <Modal styleName="modal-fixed" isOpen={!menuOpen}>
+        <Modal styleName="modal-fixed" overlayClassName="FixedNavbarModal__Overlay" isOpen={!menuOpen}>
           {this.renderFixedNavbar()}
         </Modal>
         <Modal styleName="modal-menu" isOpen={menuOpen}>


### PR DESCRIPTION
Background component has `z-index: 2` and Navbar is inside it and we can't change it to `z-index: 3`. Solution: use ReactModal to put fixed navbar on top of page.